### PR TITLE
fix: auto-focus panel + first render issue

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,54 +45,51 @@ export function activate(vsContext: vscode.ExtensionContext) {
             return;
         }
 
-        // Force to open the panel.
-        // vscode.commands.executeCommand('workbench.view.explorer');
-        vscode.commands.executeCommand('workbench.action.focusPanel');
-        vscode.commands.executeCommand('workbench.action.focusView', { "id": "queryResults" });
+        // Focus the query results panel.
+        vscode.commands.executeCommand('queryResults.focus').then(async () => {
+            const document = activeEditor.document;
+            const selection = activeEditor.selection;
+            const textSelected = activeEditor.document.getText(selection).trim();
+            const query = textSelected ? textSelected : document.getText();
 
-        const document = activeEditor.document;
-        const selection = activeEditor.selection;
-        const textSelected = activeEditor.document.getText(selection).trim();
-        const query = textSelected ? textSelected : document.getText();
+            console.log("[RunSQLCommand]", "Running query: ", query);
 
-        console.log("[RunSQLCommand]", "Running query: ", query);
+            // Identify the query to not overlap results.
+            // When a user press many times the run query button
+            // the results from one query can overlap the results
+            // from another. We only want to display the last results.
+            const id = randomUUID();
+            context.emit("event", { type: EventType.newQuery, data: { id } });
 
-        // Identify the query to not overlap results.
-        // When a user press many times the run query button
-        // the results from one query can overlap the results
-        // from another. We only want to display the last results.
-        const id = randomUUID();
-        context.emit("event", { type: EventType.newQuery, data: { id } });
+            try {
+                // Benchmark
+                const startTime = Date.now();
+                const results = await context.query(query);
+                const endTime = Date.now();
 
-        try {
+                const elapsedTime = endTime - startTime;
 
-            // Benchmark
-            const startTime = Date.now();
-            const results = await context.query(query);
-            const endTime = Date.now();
+                console.log("[RunSQLCommand]", "Results: ", results);
+                console.log("[RunSQLCommand]", "Emitting results.");
 
-            const elapsedTime = endTime - startTime;
+                if (Array.isArray(results)) {
+                    context.emit("event", { type: EventType.queryResults, data: { ...results[0], elapsedTime, id } });
+                } else {
+                    context.emit("event", { type: EventType.queryResults, data: { ...results, elapsedTime, id } });
+                }
+            } catch (error: any) {
+                console.log("[RunSQLCommand]", error.toString());
+                console.log("[RunSQLCommand]", JSON.stringify(error));
 
-            console.log("[RunSQLCommand]", "Results: ", results);
-            console.log("[RunSQLCommand]", "Emitting results.");
-
-            if (Array.isArray(results)) {
-                context.emit("event", { type: EventType.queryResults, data: { ...results[0], elapsedTime, id } });
-            } else {
-                context.emit("event", { type: EventType.queryResults, data: { ...results, elapsedTime, id } });
+                context.emit("event", { type: EventType.queryResults, data: { id, rows: [], fields: [], error: {
+                    message: error.toString(),
+                    position: error.position,
+                    query,
+                }}});
+            } finally {
+                resultsProvider._view?.show();
             }
-        } catch (error: any) {
-            console.log("[RunSQLCommand]", error.toString());
-            console.log("[RunSQLCommand]", JSON.stringify(error));
-
-            context.emit("event", { type: EventType.queryResults, data: { id, rows: [], fields: [], error: {
-                message: error.toString(),
-                position: error.position,
-                query,
-            }}});
-        } finally {
-            resultsProvider._view?.show();
-        }
+        });
     });
 
     let copyDisposable = vscode.commands.registerCommand('materialize.copy', async ({ tooltip }) => {

--- a/src/providers/scripts/results.ts
+++ b/src/providers/scripts/results.ts
@@ -212,5 +212,8 @@
                 break;
         }
     });
+
+    // Communicate to the provider that the script is ready to render data.
+    vscode.postMessage({ type: "ready" });
 }());
 


### PR DESCRIPTION
The first time a user executes a query, if the extension is not open, we need to store the results until the script renders and listens to events. Also now, the focus is done using `queryResults.focus`   