### PR TITLE
Adds ignore-paths to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,22 @@ name: Extension Test
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+      - 'README.md'
+      - 'media/**'
+      - 'resources/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+      - 'README.md'
+      - 'media/**'
+      - 'resources/**'
 
 jobs:
   build:


### PR DESCRIPTION
As per #72 adding ignore-paths to the tests workflow to ignore runs when the change was made to a `.md` file or the static assets in the `media` and `resources` directories.

Closes #72 