### PR TITLE
package: fix formatting width

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
       "properties": {
         "materialize.formattingWidth": {
           "type": "number",
-          "default": 60,
+          "default": 100,
           "description": "Maximum width for formatting code."
         }
       }


### PR DESCRIPTION
Setting the correct default formatting width defined by Matt.