### PR TITLE
refactor: from event -> procedural + async context

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,5 +49,8 @@ jobs:
         sudo apt-get install -y libnss3-dev libasound2 libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libatk1.0-0
 
     - run: npm install
-    - run: xvfb-run -a npm test
+    - name: Run Tests on Linux
       if: runner.os == 'Linux'
+      run: |
+        export MZ_CONFIG_PATH=$HOME/.config/materialize/test
+        xvfb-run -a npm test

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,10 @@
                         "outFiles": [
                                 "${workspaceFolder}/out/test/**/*.js"
                         ],
-                        "preLaunchTask": "${defaultBuildTask}"
+                        "preLaunchTask": "${defaultBuildTask}",
+                        "env": {
+                                "MZ_CONFIG_PATH": "${env:HOME}/.config/materialize/test"
+                        }
                 }
         ]
 }

--- a/src/clients/admin.ts
+++ b/src/clients/admin.ts
@@ -38,7 +38,7 @@ export default class AdminClient {
 
     async getToken() {
         // TODO: Expire should be at the half of the expiring time.
-        if (!this.auth || (new Date(this.auth.expires) > new Date())) {
+        if (!this.auth || (new Date(this.auth.expires) < new Date())) {
             const authRequest: AuthenticationRequest = {
                 clientId: this.appPassword.clientId,
                 secret: this.appPassword.secretKey
@@ -67,7 +67,7 @@ export default class AdminClient {
     }
 
     /// Returns the JSON Web Key Set (JWKS) from the well known endpoint: `/.well-known/jwks.json`
-    async getJwks() {
+    private async getJwks() {
         const client = jwksClient({
             jwksUri: this.jwksEndpoint
         });
@@ -78,7 +78,7 @@ export default class AdminClient {
 
     /// Verifies the JWT signature using a JWK from the well-known endpoint and
     /// returns the user claims.
-    async getClaims() {
+    private async getClaims() {
         console.log("[AdminClient]", "Getting Token.");
         const token = await this.getToken();
 

--- a/src/clients/cloud.ts
+++ b/src/clients/cloud.ts
@@ -1,6 +1,5 @@
 import fetch from "node-fetch";
 import AdminClient from "./admin";
-import * as vscode from 'vscode';
 import { Errors } from "../utilities/error";
 
 const DEFAULT_API_CLOUD_ENDPOINT = 'https://api.cloud.materialize.com';

--- a/src/clients/sql.ts
+++ b/src/clients/sql.ts
@@ -1,21 +1,21 @@
 import { Pool, QueryResult } from "pg";
 import AdminClient from "./admin";
 import CloudClient from "./cloud";
-import { Context, EventType } from "../context";
 import { Profile } from "../context/config";
+import AsyncContext from "../context/asyncContext";
 
 export default class SqlClient {
     private pool: Promise<Pool>;
     private adminClient: AdminClient;
     private cloudClient: CloudClient;
-    private context: Context;
+    private context: AsyncContext;
     private profile: Profile;
 
     constructor(
         adminClient: AdminClient,
         cloudClient: CloudClient,
         profile: Profile,
-        context: Context,
+        context: AsyncContext,
     ) {
         this.adminClient = adminClient;
         this.cloudClient = cloudClient;
@@ -39,7 +39,7 @@ export default class SqlClient {
                     });
                 } catch (err) {
                     console.error("[SqlClient]", "Error creating pool: ", err);
-                    this.context.emit("event", { type: EventType.error, message: err });
+                    rej(err);
                 }
             };
 

--- a/src/context/asyncContext.ts
+++ b/src/context/asyncContext.ts
@@ -294,8 +294,8 @@ export default class AsyncContext extends Context {
             this.config.setProfile(name);
             this.environment = undefined;
             try {
-                await this.reloadContext();
-                return true;
+                const success = await this.reloadContext();
+                return success;
             } catch (err) {
                 this.handleErr(err, "Error reloading context.");
                 console.error("[AsyncContext]", "Error reloading context: ", err);
@@ -327,7 +327,7 @@ export default class AsyncContext extends Context {
      * Reloads the whole context.
      */
     private async reloadContext() {
-        this.isReadyPromise = new Promise((res, rej) => {
+        this.isReadyPromise = new Promise((res) => {
             const asyncOp = async () => {
                 try {
                     await this.loadContext();

--- a/src/context/asyncContext.ts
+++ b/src/context/asyncContext.ts
@@ -257,7 +257,8 @@ export default class AsyncContext extends Context {
         try {
             await this.config.addAndSaveProfile(name, appPassword, region);
             try {
-                await this.reloadContext();
+                const success = await this.reloadContext();
+                return success;
             } catch (err) {
                 this.handleErr(err, "Error reloading context.");
             }
@@ -277,9 +278,11 @@ export default class AsyncContext extends Context {
     async removeAndSaveProfile(name: string) {
         try {
             this.config.removeAndSaveProfile(name);
-            await this.reloadContext();
+            const success = await this.reloadContext();
+            return success;
         } catch (err) {
             this.handleErr(err, "Error reloading context.");
+            return false;
         }
     }
 
@@ -414,8 +417,8 @@ export default class AsyncContext extends Context {
         }
 
         try {
-            await this.reloadEnvironment(true);
-            return true;
+            const success = await this.reloadEnvironment(true);
+            return success;
         } catch (err) {
             this.handleErr(err as Error, "Error reloading environment.");
             return false;
@@ -436,8 +439,8 @@ export default class AsyncContext extends Context {
         }
 
         try {
-            await this.reloadEnvironment();
-            return true;
+            const success = await this.reloadEnvironment();
+            return success;
         } catch (err) {
             this.handleErr(err as Error, "Error reloading environment.");
             return false;
@@ -458,8 +461,8 @@ export default class AsyncContext extends Context {
         }
 
         try {
-            await this.reloadEnvironment();
-            return true;
+            const success = await this.reloadEnvironment();
+            return success;
         } catch (err) {
             this.handleErr(err as Error, "Error reloading environment.");
             return false;

--- a/src/context/asyncContext.ts
+++ b/src/context/asyncContext.ts
@@ -1,0 +1,479 @@
+import { AdminClient, CloudClient, SqlClient } from "../clients";
+import { ExtensionContext } from "vscode";
+import { Context } from "./context";
+import { Errors, ExtensionError } from "../utilities/error";
+import AppPassword from "./appPassword";
+import { ActivityLogTreeProvider, AuthProvider, DatabaseTreeProvider, ResultsProvider } from "../providers";
+import * as vscode from 'vscode';
+import { QueryResult } from "pg";
+
+/**
+ * Represents the different providers available in the extension.
+ */
+interface Providers {
+    activity: ActivityLogTreeProvider;
+    database: DatabaseTreeProvider;
+    auth: AuthProvider;
+    results: ResultsProvider;
+}
+
+/**
+ * The context serves as a centralized point for handling
+ * asynchronous calls and distributing errors.
+ *
+ * All asynchronous methods should be declared in this class
+ * and must handle errors using try/catch, returning an error
+ * without using throw new Error().
+ *
+ * Unhandled rejections in VS Code may result in undesired
+ * notifications to the user.
+ */
+export default class AsyncContext extends Context {
+
+    protected providers: Providers;
+    private isReadyPromise: Promise<boolean>;
+
+    constructor(vsContext: ExtensionContext) {
+        super(vsContext);
+        this.isReadyPromise = new Promise((res) => {
+            const asyncOp = async () => {
+                try {
+                    await this.loadContext();
+                } catch (err) {
+                    this.handleErr(err, "Error loading context.");
+                    res(false);
+                } finally {
+                    res(true);
+                }
+            };
+            asyncOp();
+        });
+
+        // Providers must always initialize after the `isReadyPromise`.
+        // Otherwise, it will be undefined.
+        this.providers = this.buildProviders();
+    }
+
+    /**
+     * Builds the different providers in the extension.
+     *
+     * This is the only function that it is not async.
+     * The only reason is here is the circular dependency betwee providers and
+     * context.
+     */
+    private buildProviders() {
+        const activity = new ActivityLogTreeProvider(this.vsContext);
+        const database = new DatabaseTreeProvider(this);
+        const auth = new AuthProvider(this.vsContext.extensionUri, this);
+        const results = new ResultsProvider(this.vsContext.extensionUri);
+
+        // Register providers
+        vscode.window.registerTreeDataProvider('activityLog', activity);
+        vscode.window.createTreeView('explorer', { treeDataProvider: database });
+        this.vsContext.subscriptions.push(vscode.commands.registerCommand('materialize.refresh', () => {
+            database.refresh();
+        }));
+        this.vsContext.subscriptions.push(
+            vscode.window.registerWebviewViewProvider(
+                "profile",
+                auth
+            )
+        );
+        this.vsContext.subscriptions.push(
+            vscode.window.registerWebviewViewProvider(
+                "queryResults",
+                results,
+                { webviewOptions: { retainContextWhenHidden: true } }
+            )
+        );
+
+        return {
+            activity,
+            database,
+            auth,
+            results
+        };
+    }
+
+    /**
+     * Loads the Admin and Cloud clients, and
+     * triggers the environment load.
+     * @returns
+     */
+    private async loadContext(init?: boolean) {
+        const profile = this.config.getProfile();
+        this.environment = undefined;
+
+        // If there is no profile loaded skip, do not load a context.
+        if (!profile) {
+            this.loaded = true;
+            return;
+        }
+
+        console.log("[AsyncContext]", "Loading context for profile.");
+        const adminEndpoint = this.config.getAdminEndpoint();
+        const appPassword = await this.config.getAppPassword();
+        if (!appPassword) {
+            this.handleErr(Errors.missingAppPassword, "Error retrieving app-password.");
+            return;
+        }
+
+        const adminClient = new AdminClient(appPassword, adminEndpoint);
+        this.clients = {
+            ...this.clients,
+            admin: adminClient,
+            cloud: new CloudClient(adminClient, profile["cloud-endpoint"])
+        };
+        await this.loadEnvironment(init);
+    }
+
+    /**
+     * Loads all the environment information.
+     * @param reloadSchema
+     */
+    private async loadEnvironment(init?: boolean, reloadSchema?: boolean) {
+        this.loaded = false;
+
+        if (!init) {
+            this.providers.auth.environmentChange();
+            this.providers.database.refresh();
+        }
+
+        const profile = this.config.getProfile();
+
+        if (!this.clients.admin || !this.clients.cloud) {
+            throw new Error(Errors.unconfiguredClients);
+        } else if (!profile) {
+            throw new Error(Errors.unconfiguredProfile);
+        } else {
+            this.clients.sql = new SqlClient(this.clients.admin, this.clients.cloud, profile, this);
+            this.clients.sql.connectErr().catch((err) => {
+                console.error("[AsyncContext]", "Sql Client connect err: ", err);
+                this.handleErr(Errors.unexpectedSqlClientConnectionError, "Error connecting the SQL client.");
+            });
+
+            // Set environment
+            if (!this.environment) {
+                const environmentPromises = [
+                    this.query("SHOW CLUSTER;"),
+                    this.query("SHOW DATABASE;"),
+                    this.query("SHOW SCHEMA;"),
+                    this.query(`SELECT id, name, owner_id as "ownerId" FROM mz_clusters;`),
+                    this.query(`SELECT id, name, owner_id as "ownerId" FROM mz_databases;`),
+                    this.query(`SELECT id, name, database_id as "databaseId", owner_id as "ownerId" FROM mz_schemas`),
+                ];
+
+                try {
+                    const [
+                        { rows: [{ cluster }] },
+                        { rows: [{ database }] },
+                        { rows: [{ schema }] },
+                        { rows: clusters },
+                        { rows: databases },
+                        { rows: schemas }
+                    ] = await Promise.all(environmentPromises);
+
+                    const databaseObj = databases.find(x => x.name === database);
+
+                    this.environment = {
+                        cluster,
+                        database,
+                        schema,
+                        databases,
+                        schemas: schemas.filter(x => x.databaseId === databaseObj?.id),
+                        clusters
+                    };
+
+                    console.log("[AsyncContext]", "Environment:", this.environment);
+                } catch (err) {
+                    this.handleErr(err, "Erro querying the schema.");
+                }
+            }
+
+            if (reloadSchema && this.environment) {
+                console.log("[AsyncContext]", "Reloading schema.");
+                const schemaPromises = [
+                    this.query("SHOW SCHEMA;"),
+                    this.query(`SELECT id, name, database_id as "databaseId", owner_id as "ownerId" FROM mz_schemas`)
+                ];
+                const [
+                    { rows: [{ schema }] },
+                    { rows: schemas }
+                ] = await Promise.all(schemaPromises);
+
+                const { databases, database } = this.environment;
+                const databaseObj = databases.find(x => x.name === database);
+                this.environment.schema = schema;
+                this.environment.schemas = schemas.filter(x => x.databaseId === databaseObj?.id);
+            }
+
+            console.log("[AsyncContext]", "Environment loaded.");
+            this.loaded = true;
+            this.providers.auth.environmentLoaded();
+        }
+    }
+
+    /**
+     * Returns or create the SQL client once is ready.
+     *
+     * The SQL client abstracts the usage of the pg client.
+     * @returns {SqlClient}
+     */
+    private async getSqlClient(): Promise<SqlClient> {
+        if (this.clients.sql) {
+            return this.clients.sql;
+        } else {
+            // Profile needs to be created first.
+            return await new Promise((res, rej) => {
+                const asyncOp = async () => {
+                    try {
+                        await this.isReady;
+                    } catch (err) {
+                        console.error("[AsyncContext]", "Error getting SQL client: ", err);
+                    } finally {
+                        if (!this.clients.sql) {
+                            rej(new Error("Error getting SQL client."));
+                        } else {
+                            res(this.clients.sql);
+                        }
+                    }
+                };
+
+                asyncOp();
+            });
+        }
+    }
+
+    /**
+     * Adds a new profile.
+     *
+     * Requires to reload the context.
+     * @param name new profile name.
+     * @param appPassword new app-password.
+     * @param region new region name.
+     */
+    async addAndSaveProfile(name: string, appPassword: AppPassword, region: string) {
+        try {
+            await this.config.addAndSaveProfile(name, appPassword, region);
+            try {
+
+            } catch (err) {
+
+            }
+            await this.reloadContext();
+
+            return true;
+        } catch (err) {
+            this.handleErr(err, "Error saving profile.");
+
+            return false;
+        }
+    }
+
+    /**
+     * Removes a profile from the configuration
+     * and saves the changes.
+     * @param name profile name.
+     */
+    async removeAndSaveProfile(name: string) {
+        try {
+            this.config.removeAndSaveProfile(name);
+            await this.reloadContext();
+        } catch (err) {
+            this.handleErr(err, "Error reloading context.");
+        }
+    }
+
+    /**
+     * Sets the current profile in the context.
+     *
+     * This requires to reload the context.
+     * @param name valid profile name.
+     */
+    async setProfile(name: string) {
+        try {
+            this.config.setProfile(name);
+            this.environment = undefined;
+            try {
+                await this.reloadContext();
+            } catch (err) {
+                console.error("[AsyncContext]", "Error reloading context: ", err);
+            }
+        } catch (err) {
+            this.handleErr(err, "Error setting profile.");
+            console.error("[AsyncContext]", "Error setting profile: ", err);
+        }
+    }
+
+    /**
+     * Handle any error and display the error in the profile/auth component.
+     * @param err
+     * @param altMessage
+     */
+    private handleErr(err: unknown, altMessage: string) {
+        console.log("[AsyncContext]", altMessage);
+
+        if (err instanceof ExtensionError || err instanceof Error) {
+            this.providers.auth.displayError(err.message);
+          } else {
+            this.providers.auth.displayError(altMessage || Errors.unexpectedErrorContext);
+          }
+    }
+
+    /**
+     * Reloads the whole context.
+     */
+    private async reloadContext() {
+        this.isReadyPromise = new Promise((res, rej) => {
+            const asyncOp = async () => {
+                try {
+                    await this.loadContext();
+                    res(true);
+                } catch (err) {
+                    this.handleErr(err, "Error reloading context.");
+                    res(false);
+                }
+            };
+
+            asyncOp();
+        });
+
+        return this.isReadyPromise;
+    }
+
+    /**
+     * Reloads the environment with another configuration.
+     * @param reloadSchema only true when the database changes.
+     */
+    private async reloadEnvironment(reloadSchema?: boolean) {
+        this.isReadyPromise = new Promise((res, rej) => {
+            const asyncOp = async () => {
+                try {
+                    await this.loadEnvironment(false, reloadSchema);
+                    res(true);
+                } catch (err) {
+                    this.handleErr(err, "Error reloading environment.");
+                    res(false);
+                }
+            };
+
+            asyncOp();
+        });
+
+        return this.isReadyPromise;
+    }
+
+    /**
+     * Runs a query in the SQL client.
+     *
+     * WARNING: If using this method handle exceptions carefuly.
+     * @param text
+     * @param vals
+     * @returns
+     */
+    async query(text: string, vals?: Array<any>): Promise<QueryResult<any>> {
+        const client = await this.getSqlClient();
+        return await client.query(text, vals);
+    }
+
+    /**
+     * Use this method to verify if the context is ready to receive requests.
+     *
+     * Return does not means it is healthy.
+     * @returns {Promise<boolean>}
+     */
+    async isReady() {
+        try {
+            await this.isReadyPromise;
+            return true;
+        } catch (err) {
+            this.handleErr(err, "Error waiting to be ready.");
+            return false;
+        }
+    }
+
+    /**
+     * Sets a new database.
+     * Requires and environment and schema reload.
+     * @param name valid database name.
+     */
+    async setDatabase(name: string) {
+        // Every database has different schemas.
+        // Setting an undefined schema before loading the env.
+        // Triggers a new search for a valid schema.
+        if (this.environment) {
+            // Reload schema after loading the environment.
+            this.environment = {
+                ...this.environment,
+                database: name,
+                schema: "",
+            };
+        }
+
+        try {
+            await this.reloadEnvironment(true);
+        } catch (err) {
+            this.handleErr(err as Error, "Error reloading environment.");
+        }
+    }
+
+    /**
+     * Sets a new cluster.
+     * Requires an environment reload.
+     * @param name valid cluster name.
+     */
+    async setCluster(name: string) {
+        if (this.environment) {
+            this.environment = {
+                ...this.environment,
+                cluster: name,
+            };
+        }
+
+        try {
+            await this.reloadEnvironment();
+        } catch (err) {
+            this.handleErr(err as Error, "Error reloading environment.");
+        }
+    }
+
+    /**
+     * Sets a new schema.
+     * Requires an environment reload.
+     * @param name valid schema name.
+     */
+    async setSchema(name: string) {
+        if (this.environment) {
+            this.environment = {
+                ...this.environment,
+                schema: name,
+            };
+        }
+
+        try {
+            await this.reloadEnvironment();
+        } catch (err) {
+            this.handleErr(err as Error, "Error reloading environment.");
+        }
+    }
+
+    /**
+     * @returns the current user app-password.
+     */
+    async getAppPassword() {
+        try {
+            const appPassword = await this.config.getAppPassword();
+            return appPassword;
+        } catch (err) {
+            this.handleErr(err, "Error getting app-password.");
+            return undefined;
+        }
+    }
+
+    /**
+     * @returns the available providers.
+     */
+    getProviders(): Providers {
+        return this.providers;
+    }
+}

--- a/src/context/config.ts
+++ b/src/context/config.ts
@@ -374,8 +374,13 @@ export class Config {
 
         if (this.config.profiles) {
             const profile = this.config.profiles[name];
-            this.profile = profile;
-            this.profileName = name;
+
+            if (!profile) {
+                throw new Error("Profile does not exists.");
+            } else {
+                this.profile = profile;
+                this.profileName = name;
+            }
         } else {
             console.error("Error loading profile. The profile is missing.");
         }

--- a/src/context/config.ts
+++ b/src/context/config.ts
@@ -322,13 +322,10 @@ export class Config {
      */
     async getAppPassword(): Promise<string | undefined> {
         const {
-            vault,
             appPassword
         } = this.profile ? {
-            vault: this.profile.vault,
             appPassword: this.profile["app-password"]
         } : {
-            vault: this.config.vault,
             appPassword: undefined
         };
 

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -1,21 +1,12 @@
-import EventEmitter = require("node:events");
 import { AdminClient, CloudClient, SqlClient } from "../clients";
 import { Config } from "./config";
 import { MaterializeObject, MaterializeSchemaObject } from "../providers/schema";
-import AppPassword from "./appPassword";
 import LspClient from "../clients/lsp";
-import { Errors, ExtensionError } from "../utilities/error";
+import * as vscode from 'vscode';
 
-export enum EventType {
-    newProfiles,
-    newQuery,
-    sqlClientConnected,
-    queryResults,
-    environmentLoaded,
-    environmentChange,
-    error
-}
-
+/**
+ * Contains Materialize environment info.
+ */
 interface Environment {
     clusters: Array<MaterializeObject>;
     schemas: Array<MaterializeSchemaObject>;
@@ -25,298 +16,113 @@ interface Environment {
     cluster: string;
 }
 
-export class Context extends EventEmitter {
-    private config: Config;
-    private loaded: boolean;
+/**
+ * Represents the different clients available in the extension.
+ */
+interface Clients {
+    admin?: AdminClient;
+    cloud?: CloudClient;
+    sql?: SqlClient;
+    lsp: LspClient;
+}
 
-    private adminClient?: AdminClient;
-    private cloudClient?: CloudClient;
-    private sqlClient?: SqlClient;
-    private lspClient: LspClient;
+export class Context {
+    protected config: Config;
+    protected loaded: boolean;
 
-    private environment?: Environment;
+    // Visual Studio Code Context
+    protected vsContext: vscode.ExtensionContext;
 
-    constructor() {
-        super();
+    // Clients
+    protected clients: Clients;
+
+    // User environment
+    protected environment?: Environment;
+
+    constructor(vsContext: vscode.ExtensionContext) {
+        this.vsContext = vsContext;
         this.config = new Config();
         this.loaded = false;
-        this.lspClient = new LspClient();
-        this.loadContext();
+        this.clients = {
+            lsp: new LspClient()
+        };
     }
 
-    private async loadContext() {
-        const profile = this.config.getProfile();
-        this.environment = undefined;
-
-        // If there is no profile loaded skip, do not load a context.
-        if (!profile) {
-            this.loaded = true;
-            return;
-        }
-
-        console.log("[Context]", "Loading context for profile.");
-        try {
-            const adminEndpoint = this.config.getAdminEndpoint();
-            const appPassword = await this.config.getAppPassword();
-            if (!appPassword) {
-                console.error("[Context]", "Missing app-password.");
-                this.emit("event", { type: EventType.error, message: Errors.missingAppPassword });
-                return;
-            }
-
-            this.adminClient = new AdminClient(appPassword, adminEndpoint);
-            this.cloudClient = new CloudClient(this.adminClient, profile["cloud-endpoint"]);
-            this.loadEnvironment();
-        } catch (err) {
-            console.error("[Context]", err);
-            this.emit("event", { type: EventType.error, message: Errors.unexpectedErrorContext });
-        }
-    }
-
-    /**
-     * @returns the current user app-password.
-     */
-    async getAppPassword() {
-        return this.config.getAppPassword();
-    }
-
-    private async loadEnvironment(reloadSchema?: boolean) {
-        this.loaded = false;
-        this.emit("event", { type: EventType.environmentChange });
-
-        const profile = this.config.getProfile();
-
-        if (!this.adminClient || !this.cloudClient) {
-            throw new Error(Errors.unconfiguredClients);
-        } else if (!profile) {
-            throw new Error(Errors.unconfiguredProfile);
-        } else {
-            this.sqlClient = new SqlClient(this.adminClient, this.cloudClient, profile, this);
-            this.sqlClient.connectErr().catch((err) => {
-                console.error("[Context]", "Sql Client connect err: ", err);
-                this.emit("event", { type: EventType.error, message: Errors.unexpectedSqlClientConnectionError });
-            });
-
-            // Set environment
-            if (!this.environment) {
-                const environmentPromises = [
-                    this.query("SHOW CLUSTER;"),
-                    this.query("SHOW DATABASE;"),
-                    this.query("SHOW SCHEMA;"),
-                    this.query(`SELECT id, name, owner_id as "ownerId" FROM mz_clusters;`),
-                    this.query(`SELECT id, name, owner_id as "ownerId" FROM mz_databases;`),
-                    this.query(`SELECT id, name, database_id as "databaseId", owner_id as "ownerId" FROM mz_schemas`),
-                ];
-
-                try {
-                    const [
-                        { rows: [{ cluster }] },
-                        { rows: [{ database }] },
-                        { rows: [{ schema }] },
-                        { rows: clusters },
-                        { rows: databases },
-                        { rows: schemas }
-                    ] = await Promise.all(environmentPromises);
-
-                    const databaseObj = databases.find(x => x.name === database);
-
-                    this.environment = {
-                        cluster,
-                        database,
-                        schema,
-                        databases,
-                        schemas: schemas.filter(x => x.databaseId === databaseObj?.id),
-                        clusters
-                    };
-
-                    console.log("[Context]", "Environment:", this.environment);
-                } catch (err) {
-                    // TODO: Display error.
-                    console.error("[Context]", "Error loading environment: ", err);
-                }
-            }
-
-            if (reloadSchema && this.environment) {
-                // TODO: Improve this code.
-                console.log("[Context]", "Reloading schema.");
-                const schemaPromises = [
-                    this.query("SHOW SCHEMA;"),
-                    this.query(`SELECT id, name, database_id as "databaseId", owner_id as "ownerId" FROM mz_schemas`)
-                ];
-                const [
-                    { rows: [{ schema }] },
-                    { rows: schemas }
-                ] = await Promise.all(schemaPromises);
-
-                const { databases, database } = this.environment;
-                const databaseObj = databases.find(x => x.name === database);
-                this.environment.schema = schema;
-                this.environment.schemas = schemas.filter(x => x.databaseId === databaseObj?.id);
-            }
-
-            console.log("[Context]", "Environment loaded.");
-            this.loaded = true;
-            this.emit("event", { type: EventType.environmentLoaded });
-        }
+    stop() {
+        this.clients.lsp.stop();
     }
 
     isLoading(): boolean {
         return !this.loaded;
     }
 
-    async waitReadyness(): Promise<boolean> {
-        return await new Promise((res, rej) => {
-            if (this.loaded === true) {
-                res(true);
-            } else {
-                this.on("event", ({ type }) => {
-                    if (type === EventType.environmentLoaded) {
-                        if (!this.environment) {
-                            rej(new Error("Error getting environment."));
-                        } else {
-                            res(true);
-                        }
-                    }
-                });
-            }
-        });
-    }
-
-    private async getSqlClient(): Promise<SqlClient> {
-        if (this.sqlClient) {
-            return this.sqlClient;
-        } else {
-            // Profile needs to be created first.
-            return await new Promise((res, rej) => {
-                this.on("event", ({ type }) => {
-                    if (type === EventType.sqlClientConnected) {
-                        if (!this.sqlClient) {
-                            rej(new Error("Error getting SQL client."));
-                        } else {
-                            res(this.sqlClient);
-                        }
-                    }
-                });
-            });
-        }
-    }
-
-    stop() {
-        this.lspClient.stop();
-    }
-
-    async query(text: string, vals?: Array<any>) {
-        const client = await this.getSqlClient();
-
-        return await client.query(text, vals);
-    }
-
+    /**
+     * Returns all the clusters available in the environment.
+     * @returns cluster objects.
+     */
     getClusters(): MaterializeObject[] | undefined {
         return this.environment?.clusters;
     }
 
+    /**
+     * Return the current cluster name.
+     * @returns cluster name.
+     */
     getCluster(): string | undefined {
         return this.environment?.cluster;
     }
 
+    /**
+     * Return all the available database in the environment.
+     * @returns database objects.
+     */
     getDatabases(): MaterializeObject[] | undefined {
         return this.environment?.databases;
     }
 
+    /**
+     * Returns the current database.
+     * @returns database name.
+     */
     getDatabase(): string | undefined {
         return this.environment?.database;
     }
 
+    /**
+     * Returns all the available schemas in the environment database.
+     * @returns schema objects.
+     */
     getSchemas(): MaterializeSchemaObject[] | undefined {
         return this.environment?.schemas;
     }
 
+    /**
+     * Returns the current schema.
+     * @returns schema.
+     */
     getSchema(): string | undefined {
         return this.environment?.schema;
     }
 
+    /**
+     * Returns all the valid profile names in the config file.
+     * @returns {array} profile names
+     */
     getProfileNames() {
         return this.config.getProfileNames();
     }
 
+    /**
+     * Returns the current profile name.
+     * @returns {string} profile name.
+     */
     getProfileName() {
         return this.config.getProfileName();
     }
 
-    async addAndSaveProfile(name: string, appPassword: AppPassword, region: string) {
-        await this.config.addAndSaveProfile(name, appPassword, region);
-        await this.loadContext();
-    }
-
-    async removeAndSaveProfile(name: string) {
-        this.config.removeAndSaveProfile(name);
-        await this.loadContext();
-    }
-
-    async setProfile(name: string) {
-        this.config.setProfile(name);
-        this.environment = undefined;
-        await this.loadContext();
-    }
-
-    handleErr(err: Error) {
-        if (err instanceof ExtensionError) {
-            this.emit("event", { type: EventType.error, message: err.message });
-          } else {
-            this.emit("event", { type: EventType.error, message: Errors.unexpectedErrorContext });
-          }
-    }
-
-    setDatabase(name: string) {
-        // Every database has different schemas.
-        // Setting an undefined schema before loading the env.
-        // Triggers a new search for a valid schema.
-        if (this.environment) {
-            // Reload schema after loading the environment.
-            this.environment = {
-                ...this.environment,
-                database: name,
-                schema: "",
-            };
-        }
-
-        try {
-            this.loadEnvironment(true);
-        } catch (err) {
-            this.handleErr(err as Error);
-        }
-    }
-
-    setCluster(name: string) {
-        if (this.environment) {
-            this.environment = {
-                ...this.environment,
-                cluster: name,
-            };
-        }
-
-        try {
-            this.loadEnvironment();
-        } catch (err) {
-            this.handleErr(err as Error);
-        }
-    }
-
-    setSchema(name: string) {
-        if (this.environment) {
-            this.environment = {
-                ...this.environment,
-                schema: name,
-            };
-        }
-
-        try {
-            this.loadEnvironment();
-        } catch (err) {
-            this.handleErr(err as Error);
-        }
-    }
-
+    /**
+     * @returns context environment
+     */
     getEnvironment() {
         return this.environment;
     }

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,6 +1,5 @@
-import Context, { EventType } from "./context";
+import Context from "./context";
 
 export {
     Context,
-    EventType,
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import { Context } from './context';
 import { buildRunSQLCommand } from './providers/query';
 import AsyncContext from './context/asyncContext';
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,44 +1,14 @@
 import * as vscode from 'vscode';
-import { AuthProvider, ResultsProvider, DatabaseTreeProvider, ActivityLogTreeProvider } from './providers';
-import { Context, EventType } from './context';
-import { randomUUID } from 'crypto';
+import { Context } from './context';
+import { buildRunSQLCommand } from './providers/query';
+import AsyncContext from './context/asyncContext';
 
 // User context. Contains auth information, cluster, database, schema, etc.
-let context: Context;
+let context: AsyncContext;
 
 export function activate(vsContext: vscode.ExtensionContext) {
     console.log("[Extension]", "Activating Materialize extension.");
-    context = new Context();
-
-    // Register the activity log
-    const activityLogProvider = new ActivityLogTreeProvider(vsContext);
-    vscode.window.registerTreeDataProvider('activityLog', activityLogProvider);
-
-    // Register the database explorer
-	const databaseTreeProvider = new DatabaseTreeProvider(context);
-    vscode.window.createTreeView('explorer', { treeDataProvider: databaseTreeProvider });
-
-    vsContext.subscriptions.push(vscode.commands.registerCommand('materialize.refresh', () => {
-        databaseTreeProvider.refresh();
-    }));
-
-    // Register the Auth Provider
-	const authProvider = new AuthProvider(vsContext.extensionUri, context);
-	vsContext.subscriptions.push(
-		vscode.window.registerWebviewViewProvider(
-			"profile",
-			authProvider
-		)
-	);
-
-    const resultsProvider = new ResultsProvider(vsContext.extensionUri, context);
-	vsContext.subscriptions.push(
-		vscode.window.registerWebviewViewProvider(
-			"queryResults",
-			resultsProvider,
-            { webviewOptions: { retainContextWhenHidden: true } }
-		)
-	);
+    context = new AsyncContext(vsContext);
 
     // Register the `Run SQL` command.
     let runDisposable = vscode.commands.registerCommand('materialize.run', async () => {
@@ -57,62 +27,8 @@ export function activate(vsContext: vscode.ExtensionContext) {
         }
 
         // Focus the query results panel.
-        vscode.commands.executeCommand('queryResults.focus').then(async () => {
-            const document = activeEditor.document;
-            const selection = activeEditor.selection;
-            const textSelected = activeEditor.document.getText(selection).trim();
-            const query = textSelected ? textSelected : document.getText();
-
-            console.log("[RunSQLCommand]", "Running query: ", query);
-
-            // Identify the query to not overlap results.
-            // When a user press many times the run query button
-            // the results from one query can overlap the results
-            // from another. We only want to display the last results.
-            const id = randomUUID();
-            context.emit("event", { type: EventType.newQuery, data: { id } });
-
-            // Benchmark
-            const startTime = Date.now();
-            try {
-                const results = await context.query(query);
-                const endTime = Date.now();
-                const elapsedTime = endTime - startTime;
-
-                console.log("[RunSQLCommand]", "Results: ", results);
-                console.log("[RunSQLCommand]", "Emitting results.");
-
-                if (Array.isArray(results)) {
-                    context.emit("event", { type: EventType.queryResults, data: { ...results[0], elapsedTime, id } });
-                } else {
-                    context.emit("event", { type: EventType.queryResults, data: { ...results, elapsedTime, id } });
-                }
-                activityLogProvider.addLog({
-                    status: "success",
-                    latency: elapsedTime, // assuming elapsedTime holds the time taken for the query to execute
-                    sql: query
-                });
-            } catch (error: any) {
-                console.log("[RunSQLCommand]", error.toString());
-                console.log("[RunSQLCommand]", JSON.stringify(error));
-                const endTime = Date.now();
-                const elapsedTime = endTime - startTime;
-
-                activityLogProvider.addLog({
-                    status: "failure",
-                    latency: elapsedTime, // assuming elapsedTime holds the time taken before the error was caught
-                    sql: query
-                });
-
-                context.emit("event", { type: EventType.queryResults, data: { id, rows: [], fields: [], error: {
-                    message: error.toString(),
-                    position: error.position,
-                    query,
-                }, elapsedTime }});
-            } finally {
-                resultsProvider._view?.show();
-            }
-        });
+        const sqlCommand = buildRunSQLCommand(context);
+        vscode.commands.executeCommand('queryResults.focus').then(sqlCommand);
     });
 
     let copyDisposable = vscode.commands.registerCommand('materialize.copy', async ({ tooltip }) => {

--- a/src/providers/auth.ts
+++ b/src/providers/auth.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
 import { Request, Response, Application } from 'express';
-import { Context, EventType } from "../context";
 import { getUri } from "../utilities/getUri";
 import AppPassword from "../context/appPassword";
 import { getNonce } from "../utilities/getNonce";

--- a/src/providers/auth.ts
+++ b/src/providers/auth.ts
@@ -95,13 +95,13 @@ export default class AuthProvider implements vscode.WebviewViewProvider {
 
         // Await for readyness when the extension activates from the outside.
         // E.g. Running a query without opening the extension.
-        // this.context.isReady().then(() => {
-        //     this.state = {
-        //         ...this.state,
-        //         isLoading: false,
-        //         error: undefined,
-        //     };
-        // });
+        this.context.isReady().then(() => {
+            this.state = {
+                ...this.state,
+                isLoading: false,
+                error: undefined,
+            };
+        });
     }
 
     private capitalizeFirstLetter(str: string) {

--- a/src/providers/query.ts
+++ b/src/providers/query.ts
@@ -1,0 +1,89 @@
+import * as vscode from 'vscode';
+import { randomUUID } from 'crypto';
+import AsyncContext from "../context/asyncContext";
+
+export const buildRunSQLCommand = (context: AsyncContext) => {
+    const sqlCommand = async () => {
+        const {
+            activity: activityProvider,
+            results: resultsProvider
+        } = context.getProviders();
+        console.log("[RunSQLCommand]", "Firing detected.");
+
+        // Check for available profile before proceeding.
+        if (!context.getProfileName()) {
+            vscode.window.showErrorMessage('No available profile to run the query.');
+            return;
+        }
+
+        const activeEditor = vscode.window.activeTextEditor;
+        if (!activeEditor) {
+            vscode.window.showErrorMessage('No active editor.');
+            return;
+        }
+
+        // Focus the query results panel.
+        vscode.commands.executeCommand('queryResults.focus').then(async () => {
+            const document = activeEditor.document;
+            const selection = activeEditor.selection;
+            const textSelected = activeEditor.document.getText(selection).trim();
+            const query = textSelected ? textSelected : document.getText();
+
+            console.log("[RunSQLCommand]", "Running query: ", query);
+
+            // Identify the query to not overlap results.
+            // When a user press many times the run query button
+            // the results from one query can overlap the results
+            // from another. We only want to display the last results.
+            const id = randomUUID();
+            resultsProvider.setQueryId(id);
+
+            // Benchmark
+            const startTime = Date.now();
+            try {
+                const results = await context.query(query);
+                const endTime = Date.now();
+                const elapsedTime = endTime - startTime;
+
+                console.log("[RunSQLCommand]", "Results: ", results);
+                console.log("[RunSQLCommand]", "Emitting results.");
+
+                if (Array.isArray(results)) {
+                    resultsProvider.setResults(id, { ...results[0], elapsedTime, id });
+                } else {
+                    resultsProvider.setResults(id, { ...results, elapsedTime, id });
+                }
+
+                activityProvider.addLog({
+                    status: "success",
+                    latency: elapsedTime,
+                    sql: query
+                });
+            } catch (error: any) {
+                console.log("[RunSQLCommand]", error.toString());
+                console.log("[RunSQLCommand]", JSON.stringify(error));
+                const endTime = Date.now();
+                const elapsedTime = endTime - startTime;
+
+                activityProvider.addLog({
+                    status: "failure",
+                    latency: elapsedTime, // assuming elapsedTime holds the time taken before the error was caught
+                    sql: query
+                });
+
+
+                resultsProvider.setResults(id,
+                    undefined,
+                    {
+                        message: error.toString(),
+                        position: error.position,
+                        query,
+                });
+            } finally {
+                resultsProvider._view?.show();
+            }
+        });
+    };
+
+    return sqlCommand;
+};

--- a/src/providers/results.ts
+++ b/src/providers/results.ts
@@ -1,9 +1,7 @@
 import * as vscode from "vscode";
-import { Context } from "../context";
 import { getUri } from "../utilities/getUri";
 import { getNonce } from "../utilities/getNonce";
 import { QueryResult } from "pg";
-import AsyncContext from "../context/asyncContext";
 
 interface Results extends QueryResult {
     id: string,

--- a/src/providers/results.ts
+++ b/src/providers/results.ts
@@ -1,14 +1,24 @@
 import * as vscode from "vscode";
 import { Context } from "../context";
-import { EventType } from "../context/context";
 import { getUri } from "../utilities/getUri";
 import { getNonce } from "../utilities/getNonce";
 import { QueryResult } from "pg";
+import AsyncContext from "../context/asyncContext";
+
+interface Results extends QueryResult {
+    id: string,
+    elapsedTime: number,
+}
+
+interface ResultsError {
+    message: string,
+    position: number,
+    query: string,
+}
 
 export default class ResultsProvider implements vscode.WebviewViewProvider {
     _view?: vscode.WebviewView;
     _doc?: vscode.TextDocument;
-    private context: Context;
 
     // Identifies the identifier of the last query run by the user.
     // It is used to display the results and not overlap them from the results of a laggy query.
@@ -24,43 +34,56 @@ export default class ResultsProvider implements vscode.WebviewViewProvider {
     // new data arriving and to render the information.
     private isScriptReady: boolean;
 
-    constructor(private readonly _extensionUri: vscode.Uri, context: Context) {
+    constructor(private readonly _extensionUri: vscode.Uri) {
         this._extensionUri = _extensionUri;
-        this.context = context;
         this.isScriptReady = false;
+    }
 
-        this.context.on("event", ({ type, data }) => {
-            if (this._view) {
-                if (type === EventType.queryResults) {
-                    const { id } = data;
-                    console.log("[ResultsProvider]", "New query results.", this.lastQueryId);
+    /**
+     * Cleans the results and sets a latest query id.
+     * @param id
+     */
+    public setQueryId(id: string) {
+        this.lastQueryId = id;
 
-                    // Check if the results are from the last issued query.
-                    if (this.lastQueryId === id || this.lastQueryId === undefined) {
-                        console.log("[ResultsProvider]", "Is script ready : ", this.isScriptReady);
-                        if (this.isScriptReady) {
-                            const thenable = this._view.webview.postMessage({ type: "results", data });
+        if (this._view) {
+            console.log("[ResultsProvider]", "New query.");
+            const thenable = this._view.webview.postMessage({ type: "newQuery" });
+            thenable.then((posted) => {
+                console.log("[ResultsProvider]", "Message posted: ", posted);
+            });
+        }
+    }
 
-                            thenable.then((posted) => {
-                                console.log("[ResultsProvider]", "Message posted: ", posted);
-                            });
-                        } else {
-                            console.log("[ResultsProvider]", "The script is not ready yet.");
-                            this.pendingDataToRender = data;
-                        }
-                    }
-                } else if (type === EventType.newQuery) {
-                    const { id } = data;
-                    this.lastQueryId = id;
+    /**
+     * Displays the results from the latest query.
+     * @param id
+     * @param queryResults
+     */
+    public setResults(id: string, results?: Results, error?: ResultsError) {
+        console.log("[ResultsProvider]", "New query results.", this.lastQueryId);
 
-                    console.log("[ResultsProvider]", "New query.");
-                    const thenable = this._view.webview.postMessage({ type: "newQuery", data });
+        // Check if the results are from the last issued query.
+        if (this._view && (this.lastQueryId === id || this.lastQueryId === undefined)) {
+            console.log("[ResultsProvider]", "Is script ready : ", this.isScriptReady);
+            if (this.isScriptReady) {
+
+                if (results) {
+                    const thenable = this._view.webview.postMessage({ type: "results", data: results });
+                    thenable.then((posted) => {
+                        console.log("[ResultsProvider]", "Message posted: ", posted);
+                    });
+                } else if (error) {
+                    const thenable = this._view.webview.postMessage({ type: "results", data: { error } });
                     thenable.then((posted) => {
                         console.log("[ResultsProvider]", "Message posted: ", posted);
                     });
                 }
+            } else {
+                console.log("[ResultsProvider]", "The script is not ready yet.");
+                this.pendingDataToRender = results;
             }
-        });
+        }
     }
 
     public resolveWebviewView(webviewView: vscode.WebviewView) {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -251,16 +251,9 @@ suite('Extension Test Suite', () => {
 
 	test('Detect invalid password', async () => {
         const context: AsyncContext = await extension.activate();
-		let err = false;
+		const success = await context.setProfile("invalid_profile");
 
-		try {
-			await context.setProfile("invalid_profile");
-			await context.getAppPassword();
-		} catch (error) {
-			err = true;
-		}
-
-		assert.ok(err);
+		assert.ok(success === false);
 
 	}).timeout(10000);
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -2,7 +2,6 @@
 // as well as import your extension to test it
 import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { Context, EventType } from '../../context';
 import { mockServer } from './server';
 import { Config } from '../../context/config';
 import * as os from "os";

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -253,7 +253,7 @@ suite('Extension Test Suite', () => {
         const context: AsyncContext = await extension.activate();
 		const success = await context.setProfile("invalid_profile");
 
-		assert.ok(success === false);
+		assert.ok(!success);
 
 	}).timeout(10000);
 });

--- a/src/test/suite/server.ts
+++ b/src/test/suite/server.ts
@@ -38,17 +38,6 @@ export function mockServer(): Promise<string> {
             return;
         }
 
-        // if (clientId === "52881e4b-8c72-4ec1-bcc6-f9d22155821b") {
-        //     // TODO: Return a token with a missing email.
-        //     res.json({
-        //         accessToken: token,
-        //         expires: "Mon, 31 Jul 2023 10:59:33 GMT",
-        //         expiresIn: 600,
-        //         refreshToken: "MOCK",
-        //     });
-        //     return;
-        // }
-
         res.json({
             accessToken: token,
             expires: "Mon, 31 Jul 2023 10:59:33 GMT",

--- a/src/utilities/error.ts
+++ b/src/utilities/error.ts
@@ -92,4 +92,12 @@ export enum Errors {
      * using the Postgres client.
      */
     unexpectedSqlClientConnectionError = "An unexpected error happened while establishing a connection to your region environment.",
+    /**
+     * Raises when a profile that does not exists in the configuration.
+     */
+    profileDoesNotExist = "The selected profile does not exist.",
+    /**
+     * Raises when a query fails.
+     */
+    queryFailure = "Error querying server."
 }


### PR DESCRIPTION
This is a big refactor.

* Removes all the EventEmitters all around.
* Replaces the events with procedural calls to the providers.
* A new class is added `AsyncContext` to handle all the async calls to the context and have a correct error handling. More centralization in the context.
* Separates the `RunSQLCommand` to its own file `query.ts` inside the providers folder. (We should do the same with Copy and Run)
* Providers are now created inside the context.
* Fixes issue about expired bear token.