### PR TITLE
fix release process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,6 @@ on:
     types: [created]
 
 jobs:
-
   release:
     runs-on: ubuntu-latest
     steps:
@@ -15,6 +14,13 @@ jobs:
           node-version: 18
       - run: npm install
       - run: npm run vscode:prepublish
-      - run: npm run deploy
+      - name: Runs on Pre-Release
+        if: 'github.event.prerelease'
+        run: npm run deploy-pre-release
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
+      - name: Runs on Release
+        if: '!github.event.prerelease'
+        run: npm run deploy
         env:
           VSCE_PAT: ${{ secrets.VSCE_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "npm run esbuild-base -- --minify",
+    "vscode:prepublish": "npm run esbuild -- --minify",
     "esbuild": "node esbuild",
     "esbuild-watch": "node esbuild --watch",
     "lint": "eslint src --ext ts",

--- a/src/clients/lsp.ts
+++ b/src/clients/lsp.ts
@@ -369,7 +369,7 @@ export default class LspClient {
             const parsingError = "Error parsing the statements.";
             console.error("[LSP]", (err && (err as any).message));
             if (parsingError === (err instanceof Error && err.message)) {
-                throw new ExtensionError(Errors.parsingFailure, "Syntax errors are present. For more information, please refer to the \"Problems\" tab.");
+                throw new ExtensionError(Errors.parsingFailure, "Syntax errors present in your query.");
             } else {
                 console.warn("[LSP]", "Using alternative parser, an error raised using the LSP: ", err);
                 try {


### PR DESCRIPTION
The [release process failed](https://github.com/MaterializeInc/vscode-extension/actions/runs/6878468599/job/18708219710#step:5:9) because a command changed the name in the `package.json`. This PR addresses that issue and also introduces the feature to perform **prereleases**. These are useful for testing a release before it reaches the users.