### PR TITLE
fix: remove enters and double or more spaces from the activity log

### DIFF
--- a/src/providers/activity.ts
+++ b/src/providers/activity.ts
@@ -47,8 +47,9 @@ class ActivityLogItem extends vscode.TreeItem {
     constructor(public readonly log: ActivityLog) {
         // Shorten the displayed query if it's too long
         const shortSQL = log.sql.length > 50 ? log.sql.substring(0, 50) + "..." : log.sql;
-
-        super(shortSQL, vscode.TreeItemCollapsibleState.None);
+        // Removes enters and extra spaces.
+        const cleanSQL = shortSQL.replace(/\n/g, '').replace(/\s{2,}/g, ' ');
+        super(cleanSQL, vscode.TreeItemCollapsibleState.None);
 
         // Set iconPath based on the status
         const iconName = log.status === "success" ? "success_icon.svg" : "error_icon.svg";


### PR DESCRIPTION
Removes extra spaces and enter character from the `Activity Log` label

Before:
<img width="572" alt="Screenshot 2023-11-28 at 15 57 12" src="https://github.com/MaterializeInc/vscode-extension/assets/11491779/7342ba2f-77b6-4bea-ba39-696eb42062d7">

After:
<img width="543" alt="Screenshot 2023-11-28 at 15 57 33" src="https://github.com/MaterializeInc/vscode-extension/assets/11491779/e95e8eff-ddfc-4343-9407-84f1e8bbe3a1">
