### PR TITLE
improvement: preserve focus after running query

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,7 @@ export function activate(vsContext: vscode.ExtensionContext) {
 
         // Focus the query results panel.
         const sqlCommand = buildRunSQLCommand(context);
-        vscode.commands.executeCommand('queryResults.focus').then(sqlCommand);
+        sqlCommand()
     });
 
     const copyDisposable = vscode.commands.registerCommand('materialize.copy', async ({ tooltip }) => {

--- a/src/providers/query.ts
+++ b/src/providers/query.ts
@@ -23,91 +23,89 @@ export const buildRunSQLCommand = (context: AsyncContext) => {
         }
 
         // Focus the query results panel.
-        vscode.commands.executeCommand('queryResults.focus').then(async () => {
-            const document = activeEditor.document;
-            const selection = activeEditor.selection;
-            const textSelected = activeEditor.document.getText(selection).trim();
-            const query = textSelected ? textSelected : document.getText();
+        const document = activeEditor.document;
+        const selection = activeEditor.selection;
+        const textSelected = activeEditor.document.getText(selection).trim();
+        const query = textSelected ? textSelected : document.getText();
 
-            // Identify the query to not overlap results.
-            // When a user press many times the run query button
-            // the results from one query can overlap the results
-            // from another. We only want to display the last results.
-            const id = randomUUID();
+        // Identify the query to not overlap results.
+        // When a user press many times the run query button
+        // the results from one query can overlap the results
+        // from another. We only want to display the last results.
+        const id = randomUUID();
+        try {
+            resultsProvider.setQueryId(id);
             try {
-                resultsProvider.setQueryId(id);
-                try {
-                    const statements = await context.parseSql(query);
-                    console.log("[RunSQLCommand]", "Running statements: ", statements);
-                    const lastStatement = statements[statements.length - 1];
+                const statements = await context.parseSql(query);
+                console.log("[RunSQLCommand]", "Running statements: ", statements);
+                const lastStatement = statements[statements.length - 1];
 
-                    for (const statement of statements) {
-                        console.log("[RunSQLCommand]", "Running statement: ", statement);
+                for (const statement of statements) {
+                    console.log("[RunSQLCommand]", "Running statement: ", statement);
 
-                        // Benchmark
-                        const startTime = Date.now();
-                        try {
-                            const results = await context.privateQuery(statement.sql);
-                            const endTime = Date.now();
-                            const elapsedTime = endTime - startTime;
+                    // Benchmark
+                    const startTime = Date.now();
+                    try {
+                        const results = await context.privateQuery(statement.sql);
+                        const endTime = Date.now();
+                        const elapsedTime = endTime - startTime;
 
-                            console.log("[RunSQLCommand]", "Results: ", results);
-                            console.log("[RunSQLCommand]", "Emitting results.");
+                        console.log("[RunSQLCommand]", "Results: ", results);
+                        console.log("[RunSQLCommand]", "Emitting results.");
 
-                            // Only display the results from the last statement.
-                            if (lastStatement === statement) {
-                                if (Array.isArray(results)) {
-                                    resultsProvider.setResults(id, { ...results[0], elapsedTime, id });
-                                } else {
-                                    resultsProvider.setResults(id, { ...results, elapsedTime, id });
-                                }
+                        // Only display the results from the last statement.
+                        if (lastStatement === statement) {
+                            if (Array.isArray(results)) {
+                                resultsProvider.setResults(id, { ...results[0], elapsedTime, id });
+                            } else {
+                                resultsProvider.setResults(id, { ...results, elapsedTime, id });
                             }
-
-                            activityProvider.addLog({
-                                status: "success",
-                                latency: elapsedTime, // assuming elapsedTime holds the time taken for the query to execute
-                                sql: statement.sql
-                            });
-                        } catch (error: any) {
-                            console.log("[RunSQLCommand]", JSON.stringify(error));
-                            const endTime = Date.now();
-                            const elapsedTime = endTime - startTime;
-
-                            activityProvider.addLog({
-                                status: "failure",
-                                latency: elapsedTime, // assuming elapsedTime holds the time taken before the error was caught
-                                sql: statement.sql
-                            });
-
-                            resultsProvider.setResults(id,
-                                undefined,
-                                {
-                                    message: error.toString(),
-                                    position: error.position,
-                                    query,
-                            });
-
-                            // Break for-loop.
-                            break;
                         }
+
+                        activityProvider.addLog({
+                            status: "success",
+                            latency: elapsedTime, // assuming elapsedTime holds the time taken for the query to execute
+                            sql: statement.sql
+                        });
+                    } catch (error: any) {
+                        console.log("[RunSQLCommand]", JSON.stringify(error));
+                        const endTime = Date.now();
+                        const elapsedTime = endTime - startTime;
+
+                        activityProvider.addLog({
+                            status: "failure",
+                            latency: elapsedTime, // assuming elapsedTime holds the time taken before the error was caught
+                            sql: statement.sql
+                        });
+
+                        resultsProvider.setResults(id,
+                            undefined,
+                            {
+                                message: error.toString(),
+                                position: error.position,
+                                query,
+                        });
+
+                        // Break for-loop.
+                        break;
                     }
-                } catch (err) {
-                    console.error("[RunSQLCommand]", err);
-                    resultsProvider.setResults(id,
-                        undefined,
-                        {
-                            message: err instanceof Error ? err.message : "Error processing your request.",
-                            position: undefined,
-                            query,
-                        }
-                    );
-
-                    console.error("[RunSQLCommand]", "Error running statement: ", err);
                 }
-            } finally {
-                resultsProvider._view?.show();
+            } catch (err) {
+                console.error("[RunSQLCommand]", err);
+                resultsProvider.setResults(id,
+                    undefined,
+                    {
+                        message: err instanceof Error ? err.message : "Error processing your request.",
+                        position: undefined,
+                        query,
+                    }
+                );
+
+                console.error("[RunSQLCommand]", "Error running statement: ", err);
             }
-        });
+        } finally {
+            resultsProvider._view?.show(true);
+        }
     };
 
     return sqlCommand;


### PR DESCRIPTION
This PR solves a known issue. https://materializeinc.slack.com/archives/C04HRFA6DDE/p1701982014491359

After running a query, the focus changes to the results and does not preserve the focus in the editor. This PR preserves the focus.